### PR TITLE
Update .gitignore to exclude game folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+./game/*
 ./build/*
 
 # Prerequisites


### PR DESCRIPTION
Added game folder to .gitignore so that whenever one of us forks the engine or branches out to make our own game, we can start with a clean copy of the engine so that our individual work remains well-separated